### PR TITLE
Compute KIDs from raw certificates

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,8 +58,12 @@ func main() {
 	for idx, v := range decoded.Cert.VaccineRecords {
 		fmt.Printf("VR %d: C=%s,ID=%s,ISS=%s\n", idx, v.Country, v.CertificateID, v.Issuer)
 	}
-	hash := sha256.Sum256(decoded.SignedBy.Raw)
-	fmt.Printf("KID: %s\n", base64.StdEncoding.EncodeToString(hash[:8]))
+	kid := decoded.Kid
+	if len(kid) == 0 && decoded.SignedBy != nil {
+		hash := sha256.Sum256(decoded.SignedBy.Raw)
+		kid = hash[:8]
+	}
+	fmt.Printf("KID: %s\n", base64.StdEncoding.EncodeToString(kid))
 	fmt.Printf("Issued At: %+v\n", decoded.IssuedAt.Format(dateFormat))
 	if decoded.SignedBy != nil {
 		fmt.Printf("Signed By: %s (issued by: %s)\n", decoded.SignedBy.Subject, decoded.SignedBy.Issuer)


### PR DESCRIPTION
Needed for German :de: keys, where it now outputs:
```
KID: XkVWZqUeeFc=
```
instead of:
````
KID: 
````
Eg: https://github.com/denysvitali/covid-cert-analysis/blob/68808789f3685eea72f2f6a07f828be011c0ce25/RESULTS.md?plain=1#L67